### PR TITLE
Introduce new flag for extra control over asset URLs output by the static_rev templatetag

### DIFF
--- a/gulp_rev/__init__.py
+++ b/gulp_rev/__init__.py
@@ -11,7 +11,7 @@ _STATIC_MAPPING = None
 
 def use_versioned_assets():
     debug = getattr(settings, 'DEBUG', False)
-    return getattr(settings, 'DJANGO_GULP_REV_USE_VERSIONED_ASSETS', not debug)
+    return getattr(settings, 'GULP_REV_USE_VERSIONED_ASSETS', not debug)
 
 def _get_mapping():
     """

--- a/gulp_rev/__init__.py
+++ b/gulp_rev/__init__.py
@@ -9,8 +9,9 @@ from django.utils.crypto import get_random_string
 _STATIC_MAPPING = None
 
 
-def is_debug():
-    return getattr(settings, 'DEBUG', False)
+def use_versioned_assets():
+    debug = getattr(settings, 'DEBUG', False)
+    return getattr(settings, 'DJANGO_GULP_REV_USE_VERSIONED_ASSETS', debug)
 
 def _get_mapping():
     """
@@ -25,7 +26,7 @@ def _get_mapping():
         manifest_path = getattr(settings,
             'DJANGO_GULP_REV_PATH',
             os.path.join(getattr(settings, 'STATIC_ROOT', ''), 'rev-manifest.json'))
-        
+
         try:
             with open(manifest_path) as manifest_file:
                 _STATIC_MAPPING = json.load(manifest_file)
@@ -71,7 +72,8 @@ def static_rev(path):
     """
     static_path = StaticNode.handle_simple(path)
 
-    if is_debug():
-        return dev_url(static_path)
+    if use_versioned_assets():
+        return production_url(path, static_path)
 
-    return production_url(path, static_path)
+    return dev_url(static_path)
+

--- a/gulp_rev/__init__.py
+++ b/gulp_rev/__init__.py
@@ -11,7 +11,7 @@ _STATIC_MAPPING = None
 
 def use_versioned_assets():
     debug = getattr(settings, 'DEBUG', False)
-    return getattr(settings, 'DJANGO_GULP_REV_USE_VERSIONED_ASSETS', debug)
+    return getattr(settings, 'DJANGO_GULP_REV_USE_VERSIONED_ASSETS', not debug)
 
 def _get_mapping():
     """

--- a/gulp_rev/tests/tests.py
+++ b/gulp_rev/tests/tests.py
@@ -23,8 +23,7 @@ class gulp_revTestCase(TestCase):
     def test_is_use_versioned_assets_true(self):
         self.assertTrue(gulp_rev.use_versioned_assets())
 
-    @override_settings(DEBUG=True)
-    @override_settings(GULP_REV_USE_VERSIONED_ASSETS=True)
+    @override_settings(DEBUG=True, GULP_REV_USE_VERSIONED_ASSETS=True)
     def test_ignores_debug_if_use_versioned_assets_specified(self):
         self.assertTrue(gulp_rev.use_versioned_assets())
 

--- a/gulp_rev/tests/tests.py
+++ b/gulp_rev/tests/tests.py
@@ -19,12 +19,12 @@ class gulp_revTestCase(TestCase):
     def test_is_debug_true(self):
         self.assertFalse(gulp_rev.use_versioned_assets())
 
-    @override_settings(DJANGO_GULP_REV_USE_VERSIONED_ASSETS=True)
+    @override_settings(GULP_REV_USE_VERSIONED_ASSETS=True)
     def test_is_use_versioned_assets_true(self):
         self.assertTrue(gulp_rev.use_versioned_assets())
 
     @override_settings(DEBUG=True)
-    @override_settings(DJANGO_GULP_REV_USE_VERSIONED_ASSETS=True)
+    @override_settings(GULP_REV_USE_VERSIONED_ASSETS=True)
     def test_ignores_debug_if_use_versioned_assets_specified(self):
         self.assertTrue(gulp_rev.use_versioned_assets())
 

--- a/gulp_rev/tests/tests.py
+++ b/gulp_rev/tests/tests.py
@@ -11,12 +11,22 @@ class gulp_revTestCase(TestCase):
         self.manifest_path = 'rev-manifest.json'
         gulp_rev._STATIC_MAPPING = None
 
+    @override_settings(DEBUG=False)
     def test_is_debug_false(self):
-        self.assertFalse(gulp_rev.is_debug())
+        self.assertTrue(gulp_rev.use_versioned_assets())
 
     @override_settings(DEBUG=True)
     def test_is_debug_true(self):
-        self.assertTrue(gulp_rev.is_debug())
+        self.assertFalse(gulp_rev.use_versioned_assets())
+
+    @override_settings(DJANGO_GULP_REV_USE_VERSIONED_ASSETS=True)
+    def test_is_use_versioned_assets_true(self):
+        self.assertTrue(gulp_rev.use_versioned_assets())
+
+    @override_settings(DEBUG=True)
+    @override_settings(DJANGO_GULP_REV_USE_VERSIONED_ASSETS=True)
+    def test_ignores_debug_if_use_versioned_assets_specified(self):
+        self.assertTrue(gulp_rev.use_versioned_assets())
 
     def test_dev_url(self):
         dev_url = gulp_rev.dev_url(self.path)


### PR DESCRIPTION
Introduces the new flag `DJANGO_GULP_REV_USE_VERSIONED_ASSETS` which, if set, allows users to have greater control over which type of assets are served.

If `DJANGO_GULP_REV_USE_VERSIONED_ASSETS` is not specified in a users settings, then it falls back to the value of DEBUG.

Closes #3